### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+asymptote (2.65-3) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Submit (from ./configure),
+    Repository.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 07:22:55 +0000
+
 asymptote (2.65-2) unstable; urgency=medium
 
   * fix doc-base specification for new location of doc files

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ asymptote (2.65-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Submit (from ./configure),
     Repository.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 07:22:55 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Build-Depends: bison,
                zlib1g-dev,
                libglm-dev,
                libglew-dev
-Standards-Version: 4.4.0
+Standards-Version: 4.5.0
 Homepage: http://asymptote.sourceforge.net/
 Vcs-Git: https://github.com/debian-tex/asymptote.git
 Vcs-Browser: https://github.com/debian-tex/asymptote

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+Bug-Submit: http://sourceforge.net/projects/asymptote
+Repository: https://asymptote.svn.sourceforge.net/svnroot/asymptote/trunk/asymptote


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Submit (from ./configure), Repository. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/asymptote/82cfbb83-eb08-4ca2-bb6c-3d46fa6ab282.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/91/7f2289981c44696ec87e48ddf5c4cd48bd97b4.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/32/3a955fbd81436e7f8b6623005bc6375c10753a.debug

No differences were encountered between the control files of package \*\*asymptote\*\*
### Control files of package asymptote-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-323a955fbd81436e7f8b6623005bc6375c10753a-] {+917f2289981c44696ec87e48ddf5c4cd48bd97b4+}

No differences were encountered between the control files of package \*\*asymptote-doc\*\*

No differences were encountered between the control files of package \*\*asymptote-x11\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/82cfbb83-eb08-4ca2-bb6c-3d46fa6ab282/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/82cfbb83-eb08-4ca2-bb6c-3d46fa6ab282/diffoscope)).
