### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 asymptote (2.83+ds-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 23 Oct 2022 18:19:50 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+asymptote (2.83+ds-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 23 Oct 2022 18:19:50 -0000
+
 asymptote (2.83+ds-1) unstable; urgency=medium
 
   * New upstream version, refresh patches.

--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,7 @@ Build-Depends: bison,
                zlib1g-dev,
                libglm-dev,
                libglew-dev
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://asymptote.sourceforge.net/
 Vcs-Git: https://github.com/debian-tex/asymptote.git

--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Build-Depends: bison,
                libglew-dev
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
-Homepage: http://asymptote.sourceforge.net/
+Homepage: https://asymptote.sourceforge.net/
 Vcs-Git: https://github.com/debian-tex/asymptote.git
 Vcs-Browser: https://github.com/debian-tex/asymptote
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/asymptote/8e400b20-3cd0-4cdd-b04b-efdc25bc6ff0.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/de/4704c95b72dee10ec793ea924f604df094f267.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/41/a3431d804bb945df5160f594dd5d88e228da70.debug
### Control files of package asymptote: lines which differ (wdiff format)
* Homepage: [-http&#8203;://asymptote.sourceforge.net/-] {+https&#8203;://asymptote.sourceforge.net/+}
### Control files of package asymptote-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-41a3431d804bb945df5160f594dd5d88e228da70-] {+de4704c95b72dee10ec793ea924f604df094f267+}
### Control files of package asymptote-doc: lines which differ (wdiff format)
* Homepage: [-http&#8203;://asymptote.sourceforge.net/-] {+https&#8203;://asymptote.sourceforge.net/+}
### Control files of package asymptote-x11: lines which differ (wdiff format)
* Homepage: [-http&#8203;://asymptote.sourceforge.net/-] {+https&#8203;://asymptote.sourceforge.net/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8e400b20-3cd0-4cdd-b04b-efdc25bc6ff0/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8e400b20-3cd0-4cdd-b04b-efdc25bc6ff0/diffoscope)).
